### PR TITLE
Replacing tabs with navigation, with more adjustments toward final layout look.

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
-    <p>Footer</p>
+      <v-btn @click="back" :disabled="this.$route.path == '/'">{{ $t("previous") }}</v-btn>
+      <v-btn @click="next" :disabled="this.$route.path == '/appendix'">{{ $t("next") }}</v-btn>
   </div>
 </template>
 
@@ -9,13 +10,90 @@
   export default {
     data () {
       return {
+        tabs: [{
+            id: 1,
+            name: "Home",
+            route: '/'
+          },
+          {
+            id: 2,
+            name: "Parties",
+            route: '/parties'
+          },
+          {
+            id: 3,
+            name: "Unit",
+            route: '/unit'
+          },
+          {
+            id: 4,
+            name: "Term",
+            route: '/term'
+          },
+          {
+            id: 5,
+            name: "Rent",
+            route: '/rent'
+          },
+          {
+            id: 6,
+            name: "Deposits",
+            route: '/deposits'
+          },
+          {
+            id: 7,
+            name: "Service & Utilities",
+            route: '/utilities'
+          },
+          {
+            id: 8,
+            name: "Additional Terms",
+            route: '/additional'
+          },
+          {
+            id: 9,
+            name: "Signatures",
+            route: '/signatures'
+          },
+          {
+            id: 10,
+            name: "Appendix",
+            route: '/appendix'
+          }
+        ],
+        text: 'Generic text loaded in each tab'
       }
     },
+    methods: {
+      next () {
+        let nextTab = null;
+        for (let item of this.tabs) {
+          if (this.$route.path == item.route) {
+            nextTab = item.id - 1;
+          }
+        }
+        nextTab >= this.tabs.length - 1 ? nextTab = 0 : nextTab = nextTab + 1;
+        this.$router.push(this.tabs[nextTab].route);
+      },
+      back () {
+        let nextTab = null;
+        for (let item of this.tabs) {
+          if (this.$route.path == item.route) {
+            nextTab = item.id - 1;
+          }
+        }
+        nextTab == 0 ? nextTab = this.tabs.length - 1 : nextTab = nextTab - 1;
+        this.$router.push(this.tabs[nextTab].route);
+      }
+    }
   }
 </script>
 
 <style scoped>
 #footer {
   background-color: grey;
+  text-align: right;
+  padding-top: 1vh;
+  padding-right: 4vw;
 }
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,16 +1,18 @@
-<template>
+<template dark>
   <div>
     <img id="ontario-logo" src="@/assets/ontario-logo.png" />
     <div class="right">
       <v-text-field
         append-icon="mic"
         flat
+        dark
         label="Search"
         prepend-inner-icon="search"
         solo-inverted
       ></v-text-field>
       <span>Profile</span>
       <span>Settings</span>
+      <langSwitcher/>
     </div>
   </div>
     <!-- <v-toolbar app>
@@ -24,7 +26,12 @@
 
 
 <script>
+import langSwitcher from  '@/components/langSwitcher.vue';
+
   export default {
+    components: {
+    langSwitcher
+    },
     data () {
       return {
       }
@@ -37,6 +44,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  background-color: black;
+  color: white;
 }
 .right {
   width: 50%;

--- a/src/components/MoreFields.vue
+++ b/src/components/MoreFields.vue
@@ -5,7 +5,7 @@
         <v-flex xs12 sm12 md12>
             <div class="centered">
                 <label>{{ $t("Number of") }} {{title | myLocale}}: </label> &nbsp;
-                <input class="counter" type="number" min="0" v-model="amount" placeholder="enter number here" @keyup="amountChanged">
+                <input class="counter" type="number" min="0" v-model="amount" placeholder="enter number here" @keyup="amountChanged" @click="amountChanged">
             </div>
         </v-flex>
       </v-layout>
@@ -35,8 +35,8 @@
 
 <style>
 .counter{
-  border: 1px solid #00bad1;
-  color: #00bad1;
+  border: 1px solid black !important;
+  color: black !important;
   text-align: center;
   border-radius: 10px;
   font-weight: 900;

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -1,11 +1,7 @@
 <template>
   <v-navigation-drawer
   permanent
-  app
   >
-    <v-toolbar dark flat>
-    </v-toolbar>
-    <v-divider></v-divider>
     <v-list dense class="pt-0">
       <template
       v-for="section in sections">
@@ -66,6 +62,9 @@
                 { title: 'Service & Utilities', icon: 'bolt', url: '/utilities' }
              ]
            },
+           { title: 'Additional Terms', icon: 'list-ul', url:'/additional' },
+           { title: 'Signatures', icon: 'signature', url: '/signatures' },
+           { title: 'Appendix', icon: 'ellipsis-h', url: '/appendix' }
         ],
         right: null
       }

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -1,33 +1,48 @@
 <template>
-  <v-navigation-drawer 
-    :mini-variant=mini
+  <v-navigation-drawer
+  permanent
+  app
   >
-    <v-toolbar flat>
-      <v-list>
-        <v-list-tile @click=collapse>
-          <v-list-tile-title class="title">
-            <font-awesome-icon size="1x" icon='bars' /> <span v-show=!mini> Table of Contents</span>
-          </v-list-tile-title>
-        </v-list-tile>
-      </v-list>
+    <v-toolbar dark flat>
     </v-toolbar>
-
     <v-divider></v-divider>
-
     <v-list dense class="pt-0">
-      <v-list-tile
-        v-for="item in items"
-        :key="item.title"
-        @click=""
-      >
-        <v-list-tile-action>
-          <font-awesome-icon size="1x" :icon=item.icon />
-        </v-list-tile-action>
-
-        <v-list-tile-content>
-          <v-list-tile-title>{{ item.title }}</v-list-tile-title>
-        </v-list-tile-content>
-      </v-list-tile>
+      <template
+      v-for="section in sections">
+        <template
+        v-if="section.items">
+          <v-list-group
+          v-bind:key="section.title">
+            <template v-slot:activator>
+              <v-list-tile>{{ section.title }}</v-list-tile>
+            </template>
+            <v-list-tile
+            v-for="item in section.items"
+            :key="item.title"
+            :to="item.url">
+              <v-list-tile-action>
+                <font-awesome-icon size="1x" :icon="item.icon"></font-awesome-icon>
+              </v-list-tile-action>
+              <v-list-tile-content>
+                <v-list-tile-title>{{ item.title }}</v-list-tile-title>
+              </v-list-tile-content>
+            </v-list-tile>
+          </v-list-group>
+        </template>
+        <template
+        v-else>
+        <v-list-tile
+        :key="section.title"
+        :to="section.url">
+          <v-list-tile-action>
+            <font-awesome-icon size="1x" :icon="section.icon"></font-awesome-icon>
+          </v-list-tile-action>
+          <v-list-tile-content>
+            <v-list-tile-title>{{ section.title }}</v-list-tile-title>
+          </v-list-tile-content>
+          </v-list-tile>
+          </template>
+      </template>
     </v-list>
   </v-navigation-drawer>
 </template>
@@ -38,12 +53,19 @@
     data () {
       return {
         mini: true,
-        items: [
-          { title: 'Money', icon: 'money-bill-alt', url: '' },
-          { title: 'Day-today', icon: 'calendar-day', url: '' },
-          { title: 'Special Rule Cases', icon: 'flag', url: '' },
-          { title: 'Changes to the Lease', icon: 'clipboard-list', url: '' },
-          { title: 'Contacts + Unit', icon: 'user-friends', url: '' },
+        sections: [
+          { title: 'Home', icon: 'home', url: '/' },
+          { title: 'Parties', icon: 'user-friends', url: '/parties'},
+          { title: 'Money',
+            icon: 'money-bill-wave', 
+             items: [
+                { title: 'Dates', icon: 'calendar-day', url: '/term' },
+                { title: 'Rent', icon: 'money-bill', url: '/rent' },
+                { title: 'Deposits', icon: 'money-check-alt', url: '/deposits' },
+                { title: 'Unit', icon: 'key', url: '/unit' },
+                { title: 'Service & Utilities', icon: 'bolt', url: '/utilities' }
+             ]
+           },
         ],
         right: null
       }

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -14,7 +14,7 @@
           <v-list-group
           v-bind:key="section.title">
             <template v-slot:activator>
-              <v-list-tile>{{ section.title }}</v-list-tile>
+              <v-list-tile>{{ section.title | myLocale }}</v-list-tile>
             </template>
             <v-list-tile
             v-for="item in section.items"
@@ -24,7 +24,7 @@
                 <font-awesome-icon size="1x" :icon="item.icon"></font-awesome-icon>
               </v-list-tile-action>
               <v-list-tile-content>
-                <v-list-tile-title>{{ item.title }}</v-list-tile-title>
+                <v-list-tile-title>{{ item.title | myLocale }}</v-list-tile-title>
               </v-list-tile-content>
             </v-list-tile>
           </v-list-group>
@@ -38,7 +38,7 @@
             <font-awesome-icon size="1x" :icon="section.icon"></font-awesome-icon>
           </v-list-tile-action>
           <v-list-tile-content>
-            <v-list-tile-title>{{ section.title }}</v-list-tile-title>
+            <v-list-tile-title>{{ section.title | myLocale }}</v-list-tile-title>
           </v-list-tile-content>
           </v-list-tile>
           </template>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -46,5 +46,8 @@
     "Yes": "Yes",
     "No": "No",
     "No Charge": "No Charge",
-    "Pay Per Use": "Pay Per Use"
+    "Pay Per Use": "Pay Per Use",
+    "Money": "Money",
+    "Term": "Term",
+    "Dates": "Dates"
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -46,5 +46,8 @@
     "Yes": "Oui",
     "No": "Non",
     "No Charge": "Gratuit",
-    "Pay Per Use": "Payer pour utilisation"
+    "Pay Per Use": "Payer pour utilisation",
+    "Money": "Argent",
+    "Term": "Durée",
+    "Dates": "Dates"
 }

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ require('../static/styles.scss');
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { library } from '@fortawesome/fontawesome-svg-core'
 
-import { faExclamation, faHome, faMoneyBillAlt, faCalendarDay, faFlag, faClipboardList, faBuilding, faUserFriends, faBars, faMoneyBill, faMoneyCheckAlt, faKey, faBolt} from '@fortawesome/free-solid-svg-icons'
+import { faExclamation, faHome, faMoneyBillAlt, faCalendarDay, faFlag, faClipboardList, faBuilding, faUserFriends, faBars, faMoneyBill, faMoneyCheckAlt, faKey, faBolt, faListUl, faSignature, faEllipsisH} from '@fortawesome/free-solid-svg-icons'
 library.add(faExclamation)
 library.add(faHome)
 library.add(faMoneyBillAlt)
@@ -23,6 +23,9 @@ library.add(faMoneyBill)
 library.add(faMoneyCheckAlt)
 library.add(faKey)
 library.add(faBolt)
+library.add(faListUl)
+library.add(faSignature)
+library.add(faEllipsisH)
 
 Vue.component('font-awesome-icon', FontAwesomeIcon)
 

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ require('../static/styles.scss');
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { library } from '@fortawesome/fontawesome-svg-core'
 
-import { faExclamation, faHome, faMoneyBillAlt, faCalendarDay, faFlag, faClipboardList, faBuilding, faUserFriends, faBars} from '@fortawesome/free-solid-svg-icons'
+import { faExclamation, faHome, faMoneyBillAlt, faCalendarDay, faFlag, faClipboardList, faBuilding, faUserFriends, faBars, faMoneyBill, faMoneyCheckAlt, faKey, faBolt} from '@fortawesome/free-solid-svg-icons'
 library.add(faExclamation)
 library.add(faHome)
 library.add(faMoneyBillAlt)
@@ -19,6 +19,10 @@ library.add(faClipboardList)
 library.add(faBuilding)
 library.add(faUserFriends)
 library.add(faBars)
+library.add(faMoneyBill)
+library.add(faMoneyCheckAlt)
+library.add(faKey)
+library.add(faBolt)
 
 Vue.component('font-awesome-icon', FontAwesomeIcon)
 

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -1,33 +1,5 @@
 <template>
   <v-content>
-    <v-tabs
-      v-model="active"
-      color="cyan"
-      dark
-      slider-color="orange"
-    >
-      <v-tab
-        ripple
-        v-for="items in this.tabs"
-        :key="items.id"
-        :to="items.route"
-      >
-        <span>{{ items.name | myLocale }}</span>
-      </v-tab>
-      <v-tab-item
-        v-for="items in this.tabs"
-        :key="items.id"
-        :value="items.route"
-      >
-        <div class="content">
-          <div class="text-xs-center">
-            <v-btn @click="back" :disabled="active == '/'">{{ $t("previous") }}</v-btn>
-            <v-btn @click="next" :disabled="active == '/appendix'">{{ $t("next") }}</v-btn>
-              <langSwitcher/>
-          </div>
-        </div>
-      </v-tab-item>
-    </v-tabs>
     <div id="mainView">
       <div id="navigation">
         <Navigation />
@@ -41,91 +13,14 @@
 </template>
 
 <script>
-import langSwitcher from  '@/components/langSwitcher.vue';
 import Navigation from  '@/components/Navigation.vue';
 
   export default {
     components: {
-      langSwitcher,
       Navigation
     },
     data () {
       return {
-        active: null,
-        tabs: [{
-            id: 1,
-            name: "Home",
-            route: '/'
-          },
-          {
-            id: 2,
-            name: "Parties",
-            route: '/parties'
-          },
-          {
-            id: 3,
-            name: "Unit",
-            route: '/unit'
-          },
-          {
-            id: 4,
-            name: "Term",
-            route: '/term'
-          },
-          {
-            id: 5,
-            name: "Rent",
-            route: '/rent'
-          },
-          {
-            id: 6,
-            name: "Deposits",
-            route: '/deposits'
-          },
-          {
-            id: 7,
-            name: "Service & Utilities",
-            route: '/utilities'
-          },
-          {
-            id: 8,
-            name: "Additional Terms",
-            route: '/additional'
-          },
-          {
-            id: 9,
-            name: "Signatures",
-            route: '/signatures'
-          },
-          {
-            id: 10,
-            name: "Appendix",
-            route: '/appendix'
-          }
-        ],
-        text: 'Generic text loaded in each tab'
-      }
-    },
-    methods: {
-      next () {
-        let nextTab = null;
-        for (let item of this.tabs) {
-          if (this.active == item.route) {
-            nextTab = item.id - 1;
-          }
-        }
-        nextTab >= this.tabs.length - 1 ? nextTab = 0 : nextTab = nextTab + 1;
-        this.$router.push(this.tabs[nextTab].route);
-      },
-      back () {
-        let nextTab = null;
-        for (let item of this.tabs) {
-          if (this.active == item.route) {
-            nextTab = item.id - 1;
-          }
-        }
-        nextTab == 0 ? nextTab = this.tabs.length - 1 : nextTab = nextTab - 1;
-        this.$router.push(this.tabs[nextTab].route);
       }
     }
   }
@@ -137,15 +32,9 @@ import Navigation from  '@/components/Navigation.vue';
   grid-template-columns: auto 5fr 1fr;
   grid-gap: 20px;
 }
-.content{
-  padding: 1% 5%;
-}
 a{
   justify-content: center;
   display: flex;
   text-decoration: none;
-}
-#mainView {
-  padding: 0 3%;
 }
 </style>


### PR DESCRIPTION
This PR removes the tab layout and replaces them with a left navbar.

### Navigation changes
The Navigation vue now iterates through one object with both nav sections, and the links within those sections; i.e., a section has a second object nested within it, and if it sees the object, it iterates through it for those links, and sets the section title as the title accordingly. 

If there is no section title, and it's just a spare link (it exists on the first level), then it renders the link without a section, below them.

``` javascript
sections: [
          { title: 'Home', icon: 'home', url: '/' },
          { title: 'Parties', icon: 'user-friends', url: '/parties'},
          { title: 'Money',
            icon: 'money-bill-wave', 
             items: [
                { title: 'Dates', icon: 'calendar-day', url: '/term' },
                { title: 'Rent', icon: 'money-bill', url: '/rent' },
                { title: 'Deposits', icon: 'money-check-alt', url: '/deposits' },
                { title: 'Unit', icon: 'key', url: '/unit' },
                { title: 'Service & Utilities', icon: 'bolt', url: '/utilities' }
             ]
           },
           { title: 'Additional Terms', icon: 'list-ul', url:'/additional' },
           { title: 'Signatures', icon: 'signature', url: '/signatures' },
           { title: 'Appendix', icon: 'ellipsis-h', url: '/appendix' }
        ]
```

### Language switcher and previous/next

Language switcher is now in the header.

Previous/next is now in the footer. They now look for the current route directly (grabbing the number of `this.$route.path`), and push to the next tab in the array from there, instead of tracking a separate `active` number. If it's at the start or end of the array, it disables the button accordingly.

### Miscellaneous

Changed some styling to black to get closer to our current Figma model. The `MoreFields` vue wasn't updating the total fields if you clicked, instead of typing in the number, so I added an event listener for that.

### Things left to do

- The footer shouldn't lower itself to the bottom of the page as content expands it; it should probably be a fixed element, with the content of the page being the only thing that scrolls and the nav relatively static, as well. This is a bit of a debate, however.
- We may not need search, so we can likely remove it; I left it as I didn't want to presume just yet.